### PR TITLE
Fix/sdk 30 deprecation

### DIFF
--- a/src/android/nl/xservices/plugins/Toast.java
+++ b/src/android/nl/xservices/plugins/Toast.java
@@ -38,6 +38,7 @@ public class Toast extends CordovaPlugin {
   private static final boolean IS_AT_LEAST_JELLY_BEAN = Build.VERSION.SDK_INT >= 16;
   private static final boolean IS_AT_LEAST_LOLLIPOP = Build.VERSION.SDK_INT >= 21;
   private static final boolean IS_AT_LEAST_PIE = Build.VERSION.SDK_INT >= 28;
+  private static final boolean IS_AT_LEAST_R = Build.VERSION.SDK_INT >= 30;
 
   // note that webView.isPaused() is not Xwalk compatible, so tracking it poor-man style
   private boolean isPaused;
@@ -106,7 +107,8 @@ public class Toast extends CordovaPlugin {
           }
 
           // if one of the custom layout options have been passed in, draw our own shape
-          if (styling != null && IS_AT_LEAST_JELLY_BEAN) {
+          // (but disabled on Android >= 11 since custom toast views are deprecated)
+          if (styling != null && IS_AT_LEAST_JELLY_BEAN && !IS_AT_LEAST_R) {
 
             // the defaults mimic the default toast as close as possible
             final String backgroundColor = styling.optString("backgroundColor", "#333333");
@@ -138,9 +140,13 @@ public class Toast extends CordovaPlugin {
             }
           }
 
-          // On Android >= 5 you can no longer rely on the 'toast.getView().setOnTouchListener',
-          // so created something funky that compares the Toast position to the tap coordinates.
-          if (IS_AT_LEAST_LOLLIPOP) {
+          if (IS_AT_LEAST_R) {
+            // On Android >= 11 the 'toast.getView()' will always return null
+            // so no touchListener can be used or mocked
+            // DO NOTHING
+          } else if (IS_AT_LEAST_LOLLIPOP) {
+            // On Android >= 5 you can no longer rely on the 'toast.getView().setOnTouchListener',
+            // so created something funky that compares the Toast position to the tap coordinates.
             getViewGroup().setOnTouchListener(new View.OnTouchListener() {
               @Override
               public boolean onTouch(View view, MotionEvent motionEvent) {


### PR DESCRIPTION
To resolve EddyVerbruggen#136.

because `Toast.getView()` returns `null` on Android 11 (API 30)

> [`public View getView ()`](https://developer.android.com/reference/android/widget/Toast#getView())
This method was deprecated in API level 30.
Custom toast views are deprecated. Apps can create a standard text toast with the makeText(android.content.Context, java.lang.CharSequence, int) method, or use a Snackbar when in the foreground. Starting from Android Build.VERSION_CODES#R, apps targeting API level Build.VERSION_CODES#R or higher that are in the background will not have custom toast views displayed.

(see other previously opened PRs EddyVerbruggen#139, EddyVerbruggen#140, and forks trying to fix it too)